### PR TITLE
feat: add clipboard copy toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <title>Copy Demo</title>
+  <style>
+    #toast {
+      display: none;
+      position: fixed;
+      bottom: 10px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #333;
+      color: #fff;
+      padding: 8px;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <textarea id="outputPrompt">Przykładowy tekst</textarea>
+  <button id="copy-btn">Kopiuj</button>
+  <div id="toast"></div>
+  <script>
+    const outputPrompt = document.getElementById('outputPrompt');
+    function showToast(message) {
+      const toast = document.getElementById('toast');
+      toast.textContent = message;
+      toast.style.display = 'block';
+      setTimeout(() => {
+        toast.style.display = 'none';
+      }, 2000);
+    }
+    document.getElementById('copy-btn').addEventListener('click', () => {
+      navigator.clipboard
+        .writeText(outputPrompt.value)
+        .then(() => showToast('Skopiowano do schowka!'))
+        .catch(() => showToast('Nie udało się skopiować.'));
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add copy and toast demo in `index.html`
- show success or failure toast based on clipboard API result

## Testing
- `node - <<'NODE'
const outputPrompt = {value:'foo'};
function showToast(msg){ console.log('toast:', msg); }
const navigator = { clipboard: { writeText: () => Promise.reject('blocked') } };
navigator.clipboard
  .writeText(outputPrompt.value)
  .then(() => showToast('Skopiowano do schowka!'))
  .catch(() => showToast('Nie udało się skopiować.'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68910c9aeb6c832f8d704c1d46f82ed7