### PR TITLE
Add clipboard error handling for copy button

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+const outputPrompt = document.getElementById('output-prompt');
+const copyBtn = document.getElementById('copy-btn');
+
+copyBtn.addEventListener('click', () => {
+  if (!navigator.clipboard) {
+    showToast("Kopiowanie nie jest obsługiwane.");
+    return;
+  }
+
+  navigator.clipboard.writeText(outputPrompt.value)
+    .then(() => showToast("Skopiowano do schowka!"))
+    .catch(err => showToast("Kopiowanie nie powiodło się."));
+});


### PR DESCRIPTION
## Summary
- add navigator.clipboard availability check
- handle clipboard copy errors and show feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910c87fdc4832fb354a98bdc17f8a4